### PR TITLE
fix prisma global client typing and path imports

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+.next/
+package-lock.json
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+.env
+.env.*

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,4 +1,4 @@
 export const runtime = "nodejs";
 // CHANGE: stop using "@/auth"
-import { handlers } from "../../../src/auth";
+import { handlers } from "../../../../src/auth";
 export const { GET, POST } = handlers;

--- a/app/api/uploads/presign/route.ts
+++ b/app/api/uploads/presign/route.ts
@@ -1,5 +1,5 @@
 // CHANGE: stop using "@/auth"
-import { auth } from "../../../src/auth";
+import { auth } from "../../../../src/auth";
 
 export async function POST(req: Request) {
   const session = await auth();

--- a/app/capsules/page.tsx
+++ b/app/capsules/page.tsx
@@ -1,6 +1,6 @@
 // app/capsules/page.tsx
 
-import { getCapsules, type Capsule } from "@/lib/api";
+import { getCapsules, type Capsule } from "../../src/lib/api";
 
 type PageProps = {
   searchParams?: { [key: string]: string | string[] | undefined };

--- a/app/feed/page.tsx
+++ b/app/feed/page.tsx
@@ -1,6 +1,6 @@
 // app/feed/page.tsx
 import React from "react";
-import { sameMonthDay } from "@/utils/dates";
+import { sameMonthDay } from "../../src/utils/dates";
 
 // Force runtime rendering (prevents static export from running fetch at build)
 export const dynamic = "force-dynamic";

--- a/app/kids/page.tsx
+++ b/app/kids/page.tsx
@@ -1,6 +1,6 @@
-import { getFeed, getMembers } from "@/lib/api";
-import ReactionBar from "@/components/ReactionBar";
-import PostCard from "@/components/PostCard";
+import { getFeed, getMembers } from "../../src/lib/api";
+import ReactionBar from "../../src/components/ReactionBar";
+import PostCard from "../../src/components/PostCard";
 
 export default async function KidsPage(){
   // show latest 5 posts + reaction buttons; no free-form text yet

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,2 +1,1 @@
 export * from "../src/lib/api";
-export { default } from "../src/lib/api";

--- a/package.json
+++ b/package.json
@@ -19,6 +19,11 @@
     "react-dom": "18.3.1",
     "zod": "3.23.8"
   },
+  "devDependencies": {
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.3.0",
+    "typescript": "^5.4.0"
+  },
   "engines": {
     "node": ">=20 <23"
   }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
-import { auth } from "@/auth";
-import { db } from "@/lib/db";
-import { tenantFromHost } from "@/lib/tenant";
-import UploadWidget from "@/components/UploadWidget";
+import { auth } from "../auth";
+import { db } from "../lib/db";
+import { tenantFromHost } from "../lib/tenant";
+import UploadWidget from "../components/UploadWidget";
 
 function fmtDate(d: Date) {
   return new Intl.DateTimeFormat("en", { dateStyle: "medium", timeStyle: "short" }).format(d);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,7 +1,7 @@
 import NextAuth from "next-auth";
 import Google from "next-auth/providers/google";
 import { PrismaAdapter } from "@auth/prisma-adapter";
-import { db } from "@/lib/db";
+import { db } from "./lib/db";
 
 declare module "next-auth" {
   interface Session {
@@ -14,10 +14,6 @@ declare module "next-auth" {
     };
   }
 }
-
-
-export const GET = handlers.GET;
-export const POST = handlers.POST;
 
 export const { handlers, auth, signIn, signOut } = NextAuth({
   adapter: PrismaAdapter(db),
@@ -41,3 +37,6 @@ export const { handlers, auth, signIn, signOut } = NextAuth({
     },
   },
 });
+
+export const GET = handlers.GET;
+export const POST = handlers.POST;

--- a/src/components/PostCard.tsx
+++ b/src/components/PostCard.tsx
@@ -1,5 +1,5 @@
 import { Post } from "@prisma/client";
-import { fmtDate } from "@/utils/dates";
+import { fmtDate } from "../utils/dates";
 
 function mediaUrl(key?: string) {
   if (!key) return "";

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -43,3 +43,16 @@ export async function presignUpload(filename: string, contentType: string) {
 export async function getCapsules(_family?: string): Promise<Capsule[]> {
   return [];
 }
+
+// additional stubs for app pages
+export async function getMembers(): Promise<any[]> {
+  return [];
+}
+
+export async function getFeed(_family: string): Promise<any[]> {
+  return [];
+}
+
+export async function getPublicFeed(_family: string): Promise<Post[]> {
+  return [];
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,3 +1,12 @@
 import { PrismaClient } from "@prisma/client";
+
+declare global {
+  // eslint-disable-next-line no-var, @typescript-eslint/naming-convention
+  var __db: PrismaClient | undefined;
+}
+
 export const db = globalThis.__db ?? new PrismaClient();
-if (process.env.NODE_ENV !== "production") (globalThis as any).__db = db;
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.__db = db;
+}

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -16,3 +16,9 @@ export function timeAgo(d: Date | string) {
   const day = Math.floor(hr / 24);
   return `${day}d ago`;
 }
+
+export function sameMonthDay(a: Date | string, b: Date | string) {
+  const da = typeof a === "string" ? new Date(a) : a;
+  const db = typeof b === "string" ? new Date(b) : b;
+  return da.getMonth() === db.getMonth() && da.getDate() === db.getDate();
+}


### PR DESCRIPTION
## Summary
- define global `__db` to avoid TypeScript errors when reusing Prisma client
- replace `@/` imports in app routes with relative paths and add utility stubs
- add missing TypeScript and type definitions to devDependencies and ignore build artifacts

## Testing
- `npm install` (fails: 403 Forbidden fetching @types/node)
- `npm run build` (fails: Unable to install required TypeScript dependencies)

------
https://chatgpt.com/codex/tasks/task_e_68a3ad21ae88832cb755f0a295c3418c