### PR TITLE
Allow family owners to manage families like admins

### DIFF
--- a/src/app/admin/families/page.tsx
+++ b/src/app/admin/families/page.tsx
@@ -40,6 +40,8 @@ export default function AdminFamiliesPage() {
   const selectedFamily: FamilyProfile | null =
     filteredFamilies.find((family) => family.id === selectedFamilyId) ?? filteredFamilies[0] ?? null;
 
+  const isAdminLikeRole = (role: FamilyProfile['members'][number]['role']) => role === 'ADMIN' || role === 'OWNER';
+
   return (
     <div className="space-y-8 pb-16">
       <header className="flex flex-col gap-4 rounded-3xl border border-slate-200 bg-white px-8 py-10 shadow-sm lg:flex-row lg:items-center lg:justify-between">
@@ -169,12 +171,14 @@ function FamilyDetail({
         <h3 className="text-lg font-semibold text-slate-900">Admins and recent activity</h3>
         <ul className="mt-4 space-y-3 text-sm text-slate-600">
           {family.members
-            .filter((member) => member.role === 'ADMIN')
+            .filter((member) => isAdminLikeRole(member.role))
             .map((member) => (
               <li key={member.id} className="flex items-center justify-between rounded-2xl border border-slate-100 bg-slate-50 px-4 py-3">
                 <span>
                   <span className="font-semibold text-slate-900">{member.name}</span>
-                  <span className="ml-2 text-xs uppercase tracking-wide text-slate-500">Admin</span>
+                  <span className="ml-2 text-xs uppercase tracking-wide text-slate-500">
+                    {member.role === 'OWNER' ? 'Owner' : 'Admin'}
+                  </span>
                 </span>
                 <span className="text-xs text-slate-500">{member.email}</span>
               </li>

--- a/src/app/admin/users/page.tsx
+++ b/src/app/admin/users/page.tsx
@@ -126,6 +126,8 @@ export default function AdminUsersPage() {
 }
 
 function deriveUsers(families: FamilyProfile[]): DerivedUser[] {
+  const isAdminLikeRole = (role: FamilyMemberProfile['role']) => role === 'ADMIN' || role === 'OWNER';
+
   const byUser = new Map<string, DerivedUser>();
   const memberLookup = new Map<string, { member: FamilyMemberProfile; family: FamilyProfile }>();
 
@@ -140,7 +142,7 @@ function deriveUsers(families: FamilyProfile[]): DerivedUser[] {
       if (!existing) {
         const globalRole = ROOT_ADMIN_EMAILS.includes(member.email.toLowerCase())
           ? 'ROOT_ADMIN'
-          : member.role === 'ADMIN'
+          : isAdminLikeRole(member.role)
             ? 'FAMILY_ADMIN'
             : 'MEMBER';
 
@@ -155,7 +157,7 @@ function deriveUsers(families: FamilyProfile[]): DerivedUser[] {
         });
       } else {
         existing.families.push(membershipEntry);
-        if (existing.globalRole !== 'ROOT_ADMIN' && member.role === 'ADMIN') {
+        if (existing.globalRole !== 'ROOT_ADMIN' && isAdminLikeRole(member.role)) {
           existing.globalRole = 'FAMILY_ADMIN';
         }
       }
@@ -172,7 +174,7 @@ function deriveUsers(families: FamilyProfile[]): DerivedUser[] {
         if (!derived.lastActivity || derived.lastActivity < post.createdAt) {
           derived.lastActivity = post.createdAt;
         }
-        if (derived.globalRole !== 'ROOT_ADMIN' && lookup?.member.role === 'ADMIN') {
+        if (derived.globalRole !== 'ROOT_ADMIN' && lookup?.member && isAdminLikeRole(lookup.member.role)) {
           derived.globalRole = 'FAMILY_ADMIN';
         }
       }

--- a/src/components/admin/FamilyAdminDashboard.tsx
+++ b/src/components/admin/FamilyAdminDashboard.tsx
@@ -4,7 +4,7 @@ import { useMemo, useState } from 'react';
 
 import { useAppState } from '@/lib/app-state';
 import { useAuth } from '@/lib/auth';
-import { PostVisibility } from '@/lib/types';
+import { FamilyProfile, PostVisibility } from '@/lib/types';
 import { StatCard } from '../ui/StatCard';
 import { FamilyFeed } from '../family/FamilyFeed';
 
@@ -31,6 +31,7 @@ export function FamilyAdminDashboard({ familyId, onBack }: FamilyAdminDashboardP
     requestConnection,
   } = useAppState();
   const { user } = useAuth();
+  const isAdminLikeRole = (role: FamilyProfile['members'][number]['role']) => role === 'ADMIN' || role === 'OWNER';
 
   const [content, setContent] = useState('');
   const [mediaUrl, setMediaUrl] = useState('');
@@ -49,7 +50,7 @@ export function FamilyAdminDashboard({ familyId, onBack }: FamilyAdminDashboardP
     }
     const membership = user.memberships.find((m) => m.familyId === family.id);
     if (!membership) {
-      return family.members.find((member) => member.role === 'ADMIN');
+      return family.members.find((member) => isAdminLikeRole(member.role));
     }
     return family.members.find((member) => member.id === membership.memberId) ?? null;
   }, [family, user]);

--- a/src/lib/app-state.tsx
+++ b/src/lib/app-state.tsx
@@ -11,6 +11,7 @@ import React, {
 
 import {
   FamilyConnectionRequest,
+  FamilyRole,
   FamilyMemberProfile,
   FamilyPost,
   FamilyProfile,
@@ -39,6 +40,8 @@ const slugify = (value: string) =>
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/(^-|-$)+/g, '');
+
+const isAdminLikeRole = (role?: FamilyRole) => role === 'ADMIN' || role === 'OWNER';
 
 type Action =
   | { type: 'SET_FAMILIES'; payload: FamilyProfile[] }
@@ -322,7 +325,7 @@ export const AppStateProvider = ({ children }: { children: ReactNode }) => {
         content,
         visibility,
         media,
-        status: author.role === 'ADMIN' ? 'approved' : 'pending',
+        status: isAdminLikeRole(author.role) ? 'approved' : 'pending',
       };
 
       updateFamily(familyId, (current) => ({

--- a/src/lib/auth.tsx
+++ b/src/lib/auth.tsx
@@ -13,6 +13,8 @@ import React, {
 import { api, getSubdomainInfo } from './api';
 import { AuthUser, FamilyRole, FamilyMembership, CreateFamilyRequest } from './types';
 
+const isAdminLikeRole = (role?: FamilyRole) => role === 'ADMIN' || role === 'OWNER';
+
 interface AuthContextType {
   user: AuthUser | null;
   loading: boolean;
@@ -119,12 +121,12 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     if (familyId) {
       return user.memberships.some(
         (m: FamilyMembership) =>
-          (m.familyId === familyId || m.familySlug === familyId) && m.role === 'ADMIN'
+          (m.familyId === familyId || m.familySlug === familyId) && isAdminLikeRole(m.role)
       );
     }
 
     // If no familyId provided, check if user can manage any family
-    return user.memberships.some((m: FamilyMembership) => m.role === 'ADMIN');
+    return user.memberships.some((m: FamilyMembership) => isAdminLikeRole(m.role));
   };
 
   const hasRole = (role: FamilyRole, familyId?: string) => {
@@ -145,11 +147,17 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     }
     
     if (!targetFamilyId) return false;
-    
+
     const membership = user.memberships.find(
       (m: FamilyMembership) => m.familyId === targetFamilyId || m.familySlug === targetFamilyId
     );
-    return membership?.role === role;
+    if (!membership) return false;
+
+    if (role === 'ADMIN') {
+      return isAdminLikeRole(membership.role);
+    }
+
+    return membership.role === role;
   };
 
   const value: AuthContextType = {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,14 @@
 export type GlobalRole = 'ROOT_ADMIN' | 'FAMILY_ADMIN' | 'MEMBER';
 
-export type FamilyRole = 'ADMIN' | 'ADULT' | 'CHILD_0_5' | 'CHILD_5_10' | 'CHILD_10_14' | 'CHILD_14_16' | 'CHILD_16_ADULT';
+export type FamilyRole =
+  | 'OWNER'
+  | 'ADMIN'
+  | 'ADULT'
+  | 'CHILD_0_5'
+  | 'CHILD_5_10'
+  | 'CHILD_10_14'
+  | 'CHILD_14_16'
+  | 'CHILD_16_ADULT';
 
 export interface FamilyMembership {
   familyId: string;


### PR DESCRIPTION
## Summary
- Treat family owners as admin-equivalent for permission checks and role handling
- Ensure admin dashboards and listings include owners alongside admins
- Approve owner-authored posts automatically like admin posts

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69384a7c65e0832cb7fa1477d23869b5)